### PR TITLE
Convenience functions to compile and watch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Throw a `ContextError` for context values of an incorrect type
 - The `preamble` used in `render` and some `show` methods can now be specified using `set_preamble`
 - `render` now supports the `ignorestatus = true` keyword parameter
+- Emulation of Typst command line interface. `typst("compile input.typ output.pdf")`
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ julia> render(1:4);
 - Render documents using the Typst compiler
     - Display in IJulia.jl, Pluto.jl, and QuartoRunner.jl notebooks
     - Use the [JuliaMono](https://github.com/cormullion/juliamono) typeface
+- Convenience functions to run `typst compile` and `typst watch`:
+    - `compile("input.typ", "output.pdf")`
+    - `watch("input.typ", "output.pdf")`
 
 ### Planned
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ julia> render(1:4);
 - Render documents using the Typst compiler
     - Display in IJulia.jl, Pluto.jl, and QuartoRunner.jl notebooks
     - Use the [JuliaMono](https://github.com/cormullion/juliamono) typeface
-- Convenience functions to run `typst compile` and `typst watch`:
-    - `compile("input.typ", "output.pdf")`
-    - `watch("input.typ", "output.pdf")`
+- Emulation of Typst command line interface.
+    - `typst("w input.typ output.pdf")`
+    - `typst(["compile", infile, outfile])
 
 ### Planned
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ julia> render(1:4);
 - Render documents using the Typst compiler
     - Display in IJulia.jl, Pluto.jl, and QuartoRunner.jl notebooks
     - Use the [JuliaMono](https://github.com/cormullion/juliamono) typeface
-- Emulation of Typst command line interface.
-    - `typst("w input.typ output.pdf")`
-    - `typst(["compile", infile, outfile])
 
 ### Planned
 

--- a/src/Commands.jl
+++ b/src/Commands.jl
@@ -533,38 +533,28 @@ showerror(io::IO, te::TypstError) = print(io,
     "TypstError: failed to `run` a `", TypstCommand, "(", te.command.parameters, ")`")
 
 """
-    typst(parameters::AbstractVector{<:AbstractString}; catch_interrupt = true, ignorestatus = true)
+    typst(args::AbstractString; catch_interrupt = true, ignorestatus = true)
 
-Run `typst` with the provided `parameters`. When `catch_interrupt` is true,
-CTRL-C quietly quits the command. When `ignorestatus` is true, a typst
-failure will not imply a julia error.
+Convenience function intended for interactive use, emulating the typst
+command line interface. Be aware, however, that it strictly splits
+`args` on spaces and does not provide any shell-style escape
+mechanism, so it will not work if there are, e.g., filenames with
+spaces.
+
+When `catch_interrupt` is true, CTRL-C quietly quits the
+command. When `ignorestatus` is true, a typst failure will not imply a
+julia error.
 
 Use `TypstCommand` if you need to capture output.
 
 # Examples
 
-    typst(["compile", "my document.typ"])
-    typst(["watch", "input.typ", "output.pdf"])
-    typst(["--version"])
-
----
-
-    typst(args::AbstractString)
-
-Convenience method intended for interactive use, emulating the typst
-command line interface. Be aware, however, that it strictly splits
-`args` on spaces and does not provide any shell-style escape
-mechanism, so if you have filenames with spaces you should use the
-previous method.
-
-# Examples
-
-    typst("c my_document.typ")
+    typst("c document.typ")
     typst("watch input.typ output.pdf")
 """
-function typst(parameters::AbstractVector{<:AbstractString};
+function typst(args::AbstractString;
                catch_interrupt = true, ignorestatus = true)
-    tc = addenv(TypstCommand(TypstCommand([parameters...]); ignorestatus),
+    tc = addenv(TypstCommand(TypstCommand(split(args)); ignorestatus),
                 "TYPST_FONT_PATHS" => julia_mono)
     if catch_interrupt
         try run(tc)
@@ -575,6 +565,6 @@ function typst(parameters::AbstractVector{<:AbstractString};
     nothing
 end
 
-typst(args::AbstractString) = typst(split(args))
+typst() = typst(split(args))
 
 end # Commands

--- a/src/Commands.jl
+++ b/src/Commands.jl
@@ -532,4 +532,36 @@ TypstError: failed to `run` a `TypstCommand(String[])`
 showerror(io::IO, te::TypstError) = print(io,
     "TypstError: failed to `run` a `", TypstCommand, "(", te.command.parameters, ")`")
 
+"""
+    compile(args...)
+
+Run `typst compile` with the provided `args`.
+
+# Examples
+
+    compile("input.typ")
+    compile("input.typ", "output.pdf")
+"""
+compile(args...) = (run(TypstCommand(["compile", args...])); nothing)
+
+"""
+    watch(args...)
+
+Run `typst watch` with the provided `args`. This will repeat
+compilation of the input file every time it is changed. Use Ctrl-C to
+quit the command.
+
+# Examples
+
+    watch("input.typ")
+    watch("input.typ", "output.pdf")
+"""
+function watch(args...)
+    try
+        run(TypstCommand(["watch", args...]))
+    catch e
+        e isa InterruptException || rethrow(e)
+    end
+end
+
 end # Commands

--- a/src/Typstry.jl
+++ b/src/Typstry.jl
@@ -17,8 +17,8 @@ using .Strings: ContextError, Mode, Typst, TypstString, TypstText, @typst_str, c
 export ContextError, Mode, Typst, TypstString, TypstText, @typst_str, code, markup, math, context, show_typst
 
 include("Commands.jl")
-using .Commands: TypstCommand, TypstError, @typst_cmd, julia_mono, preamble, render, set_preamble
-export TypstCommand, TypstError, @typst_cmd, julia_mono, preamble, render, set_preamble
+using .Commands: TypstCommand, TypstError, @typst_cmd, julia_mono, preamble, render, set_preamble, compile, watch
+export TypstCommand, TypstError, @typst_cmd, julia_mono, preamble, render, set_preamble, compile, watch
 
 """
     compile_workload(examples)

--- a/src/Typstry.jl
+++ b/src/Typstry.jl
@@ -17,8 +17,8 @@ using .Strings: ContextError, Mode, Typst, TypstString, TypstText, @typst_str, c
 export ContextError, Mode, Typst, TypstString, TypstText, @typst_str, code, markup, math, context, show_typst
 
 include("Commands.jl")
-using .Commands: TypstCommand, TypstError, @typst_cmd, julia_mono, preamble, render, set_preamble, compile, watch
-export TypstCommand, TypstError, @typst_cmd, julia_mono, preamble, render, set_preamble, compile, watch
+using .Commands: TypstCommand, TypstError, @typst_cmd, julia_mono, preamble, render, set_preamble, typst
+export TypstCommand, TypstError, @typst_cmd, julia_mono, preamble, render, set_preamble, typst
 
 """
     compile_workload(examples)

--- a/test/interface/TestCommands.jl
+++ b/test/interface/TestCommands.jl
@@ -25,9 +25,11 @@ const tc_ignorestatus = ignorestatus(tc_error)
             outfile1 = joinpath(tmpdir, "test.pdf")
             outfile2 = joinpath(tmpdir, "out.pdf")
             write(infile, "= Test Document\n")
-            typst(["compile", infile])
+            cd(tmpdir) do
+                typst("compile test.typ")
+                typst("c test.typ out.pdf")
+            end
             @test isfile(outfile1)
-            typst(["c", infile, outfile2])
             @test isfile(outfile2)
             # Only check that it runs without error.
             redirect_stdout(devnull) do

--- a/test/interface/TestCommands.jl
+++ b/test/interface/TestCommands.jl
@@ -19,20 +19,23 @@ const tc_ignorestatus = ignorestatus(tc_error)
 
     @testset "`render`" begin end
 
-    @testset "`compile`" begin
+    @testset "`typst`" begin
         mktempdir() do tmpdir
             infile = joinpath(tmpdir, "test.typ")
             outfile1 = joinpath(tmpdir, "test.pdf")
             outfile2 = joinpath(tmpdir, "out.pdf")
             write(infile, "= Test Document\n")
-            compile(infile)
+            typst(["compile", infile])
             @test isfile(outfile1)
-            compile(infile, outfile2)
+            typst(["c", infile, outfile2])
             @test isfile(outfile2)
+            # Only check that it runs without error.
+            redirect_stdout(devnull) do
+                typst("--help")
+                typst("fonts --variants")
+            end
         end
     end
-
-    @testset "`watch`" begin end
 end
 
 @testset "`Base`" begin

--- a/test/interface/TestCommands.jl
+++ b/test/interface/TestCommands.jl
@@ -18,6 +18,21 @@ const tc_ignorestatus = ignorestatus(tc_error)
     @testset "`julia_mono`" begin @test julia_mono isa String end
 
     @testset "`render`" begin end
+
+    @testset "`compile`" begin
+        mktempdir() do tmpdir
+            infile = joinpath(tmpdir, "test.typ")
+            outfile1 = joinpath(tmpdir, "test.pdf")
+            outfile2 = joinpath(tmpdir, "out.pdf")
+            write(infile, "= Test Document\n")
+            compile(infile)
+            @test isfile(outfile1)
+            compile(infile, outfile2)
+            @test isfile(outfile2)
+        end
+    end
+
+    @testset "`watch`" begin end
 end
 
 @testset "`Base`" begin


### PR DESCRIPTION
This PR makes it more convenient to run `typst compile` and `typst watch` from the Julia REPL.
```
compile("document.typ")           => typst compile document.typ
watch("input.typ", "output.typ")  => typst watch input.typ output.typ
```
The `watch` function is interrupted cleanly with CTRL-C.

Don't be shy to reject this PR if it doesn't fit your vision of the Typstry scope.
