### PR TITLE
Leverage mitex plugin to render latex equations

### DIFF
--- a/ext/LaTeXStringsExtension.jl
+++ b/ext/LaTeXStringsExtension.jl
@@ -4,6 +4,7 @@ module LaTeXStringsExtension
 import Typstry: show_typst
 using LaTeXStrings: LaTeXString, @L_str
 using Typstry: compile_workload, show_raw
+import Typstry: show_raw, backticks, indent, block, mode, enclose, math
 
 """
     show_typst(::IO, ::TypstContext, ::LaTeXString)
@@ -17,6 +18,32 @@ See also [`TypstContext`](@ref Typstry.TypstContext).
 | `LaTeXString` | `:block`, `:depth`, `:mode`, `:tab_size` |            |
 """
 show_typst(io, tc, x::LaTeXString) = show_raw(print, io, tc, x, "latex")
+
+"""
+    show_raw(f, io, tc, x, language)
+"""
+function show_raw(f, io, tc, x::LaTeXString, language)
+    _backticks, _block = "`" ^ backticks(tc), block(tc)
+
+    print(io, "#mi(")
+    print(io, _backticks, language)
+
+    if _block
+        _indent, _depth = indent(tc), depth(tc)
+
+        print(io, "\n")
+
+        for line in eachsplit(sprint(f, x), "\n")
+            println(io, _indent ^ (_depth + 1), line)
+        end
+
+        print(io, _indent ^ _depth)
+    else enclose(f, io, x, " ")
+    end
+
+    print(io, _backticks)
+    print(io, ")")
+end
 
 const examples = [L"a" => LaTeXString]
 


### PR DESCRIPTION
# Currently Rough Implementation

This pull request extends the `show_raw` method for LaTexStrings. It would be great if we could leverage mitex to render latex equations into latex. It is a rough implementation, but I wanted to spark a discussion.

## Try it out and see what you think

Import Typstry (using this branch) and Handcalcs
```julia-repl
julia> using Handcalcs

julia> using Typstry
```

This command adds mitex package to the preamble
```julia-repl
julia> context[:preamble] = TypstString(TypstText(context[:preamble] * TypstString(TypstText("#import \"@preview/mitex:0.2.4\": *\n"))))
TypstString(TypstText("#set page(margin: 1em, height: auto, width: auto, fill: white)\n#set text(16pt, font: \"JuliaMono\")\n#import \"@preview/mitex:0.2.4\": *\n"))
```

Then try the following:
```julia-repl
julia> TypstString(
       @handcalcs begin
       x = 5
       y = 20
       z = x^2 + y
       end
       ) |> render;
```

You should get an output like the following:
![CleanShot 2025-01-16 at 15 36 09@2x](https://github.com/user-attachments/assets/7967c852-6405-4b36-8989-9fc9d1134b89)

I currently opened an issue for the `[10pt]` being rendered. You can see the issue here: https://github.com/mitex-rs/mitex/issues/191

Otherwise mitex works pretty well. It can even render color:
```julia-repl
julia> TypstString(
       @handcalcs begin
       x = 5
       y = 20
       z = x^2 + y
       end color = :blue
       ) |> render;
```
![CleanShot 2025-01-16 at 15 39 34@2x](https://github.com/user-attachments/assets/f55a8b3a-6a63-4053-9cf9-148fe674937d)
